### PR TITLE
set 'role=user' when content is passed as a str

### DIFF
--- a/google/generativeai/types/content_types.py
+++ b/google/generativeai/types/content_types.py
@@ -69,6 +69,8 @@ __all__ = [
     "FunctionLibraryType",
 ]
 
+_USER_ROLE = "user"
+
 
 def pil_to_blob(img):
     bytesio = io.BytesIO()
@@ -256,7 +258,7 @@ def to_content(content: ContentType):
         return protos.Content(parts=[to_part(part) for part in content])
     else:
         # Maybe this is a Part?
-        return protos.Content(parts=[to_part(content)])
+        return protos.Content(parts=[to_part(content)], role=_USER_ROLE)
 
 
 def strict_to_content(content: StrictContentType):

--- a/tests/test_answer.py
+++ b/tests/test_answer.py
@@ -72,7 +72,9 @@ class UnitTests(parameterized.TestCase):
                 passages=[
                     {
                         "id": "0",
-                        "content": protos.Content(parts=[protos.Part(text="I am a chicken")]),
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I am a chicken")], role="user"
+                        ),
                     },
                     {
                         "id": "1",
@@ -92,15 +94,21 @@ class UnitTests(parameterized.TestCase):
                     passages=[
                         {
                             "id": "0",
-                            "content": protos.Content(parts=[protos.Part(text="I am a chicken")]),
+                            "content": protos.Content(
+                                parts=[protos.Part(text="I am a chicken")], role="user"
+                            ),
                         },
                         {
                             "id": "1",
-                            "content": protos.Content(parts=[protos.Part(text="I am a bird.")]),
+                            "content": protos.Content(
+                                parts=[protos.Part(text="I am a bird.")], role="user"
+                            ),
                         },
                         {
                             "id": "2",
-                            "content": protos.Content(parts=[protos.Part(text="I can fly!")]),
+                            "content": protos.Content(
+                                parts=[protos.Part(text="I can fly!")], role="user"
+                            ),
                         },
                     ]
                 ),
@@ -108,9 +116,9 @@ class UnitTests(parameterized.TestCase):
             dict(
                 testcase_name="content_object",
                 inline_passages=[
-                    protos.Content(parts=[protos.Part(text="I am a chicken")]),
-                    protos.Content(parts=[protos.Part(text="I am a bird.")]),
-                    protos.Content(parts=[protos.Part(text="I can fly!")]),
+                    protos.Content(parts=[protos.Part(text="I am a chicken")], role="user"),
+                    protos.Content(parts=[protos.Part(text="I am a bird.")], role="user"),
+                    protos.Content(parts=[protos.Part(text="I can fly!")], role="user"),
                 ],
             ),
             dict(
@@ -127,13 +135,22 @@ class UnitTests(parameterized.TestCase):
                 passages=[
                     {
                         "id": "0",
-                        "content": protos.Content(parts=[protos.Part(text="I am a chicken")]),
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I am a chicken")], role="user"
+                        ),
                     },
                     {
                         "id": "1",
-                        "content": protos.Content(parts=[protos.Part(text="I am a bird.")]),
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I am a bird.")], role="user"
+                        ),
                     },
-                    {"id": "2", "content": protos.Content(parts=[protos.Part(text="I can fly!")])},
+                    {
+                        "id": "2",
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I can fly!")], role="user"
+                        ),
+                    },
                 ]
             ),
             x,
@@ -152,13 +169,16 @@ class UnitTests(parameterized.TestCase):
             testcase_name="list_of_grounding_passages",
             inline_passages=[
                 protos.GroundingPassage(
-                    id="4", content=protos.Content(parts=[protos.Part(text="I am a chicken")])
+                    id="4",
+                    content=protos.Content(parts=[protos.Part(text="I am a chicken")], role="user"),
                 ),
                 protos.GroundingPassage(
-                    id="5", content=protos.Content(parts=[protos.Part(text="I am a bird.")])
+                    id="5",
+                    content=protos.Content(parts=[protos.Part(text="I am a bird.")], role="user"),
                 ),
                 protos.GroundingPassage(
-                    id="6", content=protos.Content(parts=[protos.Part(text="I can fly!")])
+                    id="6",
+                    content=protos.Content(parts=[protos.Part(text="I can fly!")], role="user"),
                 ),
             ],
         ),
@@ -171,13 +191,22 @@ class UnitTests(parameterized.TestCase):
                 passages=[
                     {
                         "id": "4",
-                        "content": protos.Content(parts=[protos.Part(text="I am a chicken")]),
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I am a chicken")], role="user"
+                        ),
                     },
                     {
                         "id": "5",
-                        "content": protos.Content(parts=[protos.Part(text="I am a bird.")]),
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I am a bird.")], role="user"
+                        ),
                     },
-                    {"id": "6", "content": protos.Content(parts=[protos.Part(text="I can fly!")])},
+                    {
+                        "id": "6",
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I can fly!")], role="user"
+                        ),
+                    },
                 ]
             ),
             x,
@@ -197,15 +226,21 @@ class UnitTests(parameterized.TestCase):
                 passages=[
                     {
                         "id": "first",
-                        "content": protos.Content(parts=[protos.Part(text="I am a chicken")]),
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I am a chicken")], role="user"
+                        ),
                     },
                     {
                         "id": "second",
-                        "content": protos.Content(parts=[protos.Part(text="I am a bird.")]),
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I am a bird.")], role="user"
+                        ),
                     },
                     {
                         "id": "third",
-                        "content": protos.Content(parts=[protos.Part(text="I can fly!")]),
+                        "content": protos.Content(
+                            parts=[protos.Part(text="I can fly!")], role="user"
+                        ),
                     },
                 ]
             ),
@@ -219,9 +254,22 @@ class UnitTests(parameterized.TestCase):
         inline_passages = ["I am a chicken", "I am a bird.", "I can fly!"]
         grounding_passages = protos.GroundingPassages(
             passages=[
-                {"id": "0", "content": protos.Content(parts=[protos.Part(text="I am a chicken")])},
-                {"id": "1", "content": protos.Content(parts=[protos.Part(text="I am a bird.")])},
-                {"id": "2", "content": protos.Content(parts=[protos.Part(text="I can fly!")])},
+                {
+                    "id": "0",
+                    "content": protos.Content(
+                        parts=[protos.Part(text="I am a chicken")], role="user"
+                    ),
+                },
+                {
+                    "id": "1",
+                    "content": protos.Content(
+                        parts=[protos.Part(text="I am a bird.")], role="user"
+                    ),
+                },
+                {
+                    "id": "2",
+                    "content": protos.Content(parts=[protos.Part(text="I can fly!")], role="user"),
+                },
             ]
         )
 

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -70,7 +70,7 @@ class UnitTests(parameterized.TestCase):
             self.observed_requests[-1],
             protos.EmbedContentRequest(
                 model=DEFAULT_EMB_MODEL,
-                content=protos.Content(parts=[protos.Part(text="What are you?")]),
+                content=protos.Content(parts=[protos.Part(text="What are you?")], role="user"),
             ),
         )
         self.assertIsInstance(emb["embedding"][0], float)

--- a/tests/test_embedding_async.py
+++ b/tests/test_embedding_async.py
@@ -69,7 +69,7 @@ class AsyncTests(parameterized.TestCase, unittest.IsolatedAsyncioTestCase):
             self.observed_requests[-1],
             protos.EmbedContentRequest(
                 model=DEFAULT_EMB_MODEL,
-                content=protos.Content(parts=[protos.Part(text="What are you?")]),
+                content=protos.Content(parts=[protos.Part(text="What are you?")], role="user"),
             ),
         )
         self.assertIsInstance(emb["embedding"][0], float)

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -24,8 +24,8 @@ TEST_IMAGE_URL = "https://storage.googleapis.com/generativeai-downloads/data/tes
 TEST_IMAGE_DATA = TEST_IMAGE_PATH.read_bytes()
 
 
-def simple_part(text: str) -> protos.Content:
-    return protos.Content({"parts": [{"text": text}]})
+def simple_part(text: str, role: str = "user") -> protos.Content:
+    return protos.Content({"parts": [{"text": text}], "role": role})
 
 
 def noop(x: int):
@@ -37,7 +37,9 @@ def iter_part(texts: Iterable[str]) -> protos.Content:
 
 
 def simple_response(text: str) -> protos.GenerateContentResponse:
-    return protos.GenerateContentResponse({"candidates": [{"content": simple_part(text)}]})
+    return protos.GenerateContentResponse(
+        {"candidates": [{"content": simple_part(text, role="model")}]}
+    )
 
 
 class MockGenerativeServiceClient:
@@ -801,7 +803,7 @@ class CUJTests(parameterized.TestCase):
         [
             "part_dict",
             {"parts": [{"text": "talk like a pirate"}]},
-            simple_part("talk like a pirate"),
+            protos.Content(parts=[{"text": "talk like a pirate"}]),
         ],
         ["part_list", ["talk like:", "a pirate"], iter_part(["talk like:", "a pirate"])],
     )
@@ -914,7 +916,8 @@ class CUJTests(parameterized.TestCase):
                           {
                             "text": "world!"
                           }
-                        ]
+                        ],
+                        "role": "model"
                       }
                     }
                   ]
@@ -947,7 +950,8 @@ class CUJTests(parameterized.TestCase):
                           {
                             "text": "first"
                           }
-                        ]
+                        ],
+                        "role": "model"
                       }
                     }
                   ]
@@ -972,7 +976,8 @@ class CUJTests(parameterized.TestCase):
                           {
                             "text": "first second"
                           }
-                        ]
+                        ],
+                        "role": "model"
                       },
                       "index": 0,
                       "citation_metadata": {}
@@ -1001,7 +1006,8 @@ class CUJTests(parameterized.TestCase):
                           {
                             "text": "first second third"
                           }
-                        ]
+                        ],
+                        "role": "model"
                       },
                       "index": 0,
                       "citation_metadata": {}
@@ -1093,7 +1099,8 @@ class CUJTests(parameterized.TestCase):
                           {
                             "text": "123"
                           }
-                        ]
+                        ],
+                        "role": "model"
                       },
                       "index": 0,
                       "citation_metadata": {}
@@ -1152,7 +1159,8 @@ class CUJTests(parameterized.TestCase):
                           {
                             "text": "abc"
                           }
-                        ]
+                        ],
+                        "role": "model"
                       },
                       "finish_reason": "SAFETY",
                       "index": 0,
@@ -1168,6 +1176,7 @@ class CUJTests(parameterized.TestCase):
               parts {
                 text: "abc"
               }
+              role: "model"
             }
             finish_reason: SAFETY
             citation_metadata {


### PR DESCRIPTION
'to_content' method assigns a default 'role=user' to all the contents passed as a string

Change-Id: I748514a7839b7f1d36150b879c3d1464ca9e11ba